### PR TITLE
fix(overlay-panel): re-check retention after the off-main window fetch

### DIFF
--- a/Ice/MenuBar/Appearance/MenuBarAppearanceManager.swift
+++ b/Ice/MenuBar/Appearance/MenuBarAppearanceManager.swift
@@ -63,12 +63,14 @@ final class MenuBarAppearanceManager: ObservableObject {
                 guard let self else {
                     return
                 }
+                // `popFirst()` empties the set, so the screen comparison that used to
+                // guard the call below compared an already-empty set against the current
+                // screens and was therefore always true. Reconfigure unconditionally,
+                // which is what effectively happened all along.
                 while let panel = overlayPanels.popFirst() {
                     panel.orderOut(self)
                 }
-                if Set(overlayPanels.map { $0.owningScreen }) != Set(NSScreen.screens) {
-                    configureOverlayPanels(with: configuration)
-                }
+                configureOverlayPanels(with: configuration)
             }
             .store(in: &c)
 

--- a/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -331,6 +331,18 @@ final class MenuBarOverlayPanel: NSPanel {
         // enumeration; fetch off-main so a busy window server can't freeze the
         // panel show (fire.10.4.1).
         let windows = await Task.detached { WindowInfo.createWindows(option: .onScreen) }.value
+
+        // The await above suspends this task. If the display configuration changes
+        // while it is suspended, the appearance manager drops every panel from its
+        // set and orders it out, so the retention check performed before the await
+        // is stale by the time we get here. Without re-checking, we order a panel
+        // that nobody owns any more back in, positioned from the frame its screen
+        // had before the change, and no one is left to ever order it out again.
+        guard appState.appearanceManager.overlayPanels.contains(self) else {
+            MenuBarOverlayPanel.logger.warning("Overlay panel \(self) was discarded while showing")
+            return
+        }
+
         guard validate(for: .showing, with: windows) else {
             return
         }


### PR DESCRIPTION
## Symptom

A grey bar lying across every window on both monitors, at window level 25, surviving every interaction until Ice was relaunched. `CGWindowListCopyWindowInfo` on the affected machine (macOS 26.3.1, `0.11.13-fire.10.8`, two 5K displays plus the internal one):

```
lay  owner      x      y      w      h   title
 25  Ice        0    323   1728    38   Menu Bar Overlay
 25  Ice     1728    323   1920    35   Menu Bar Overlay
 25  Ice        0      0   2560    35   Menu Bar Overlay   <- correct
 25  Ice     2560      0   2560    35   Menu Bar Overlay   <- correct
```

Two panels sit at `y=323` instead of `y=0`, and their widths (1728 pt, 1920 pt) belong to a display arrangement that no longer existed. Together they span x=0…3648, which reads as one continuous bar across both externals. `killall Ice && open -a Ice` clears it; it comes back on a later display change.

This looks like the long-standing upstream reports (#517 "Bar in the middle of the screen", #636), but the mechanism below is specific to this fork.

## Cause

Since fire.10.4.1, `MenuBarOverlayPanel.show()` is `async` and awaits an off-main window enumeration before positioning the panel:

```swift
guard appState.appearanceManager.overlayPanels.contains(self) else { … }   // retention check
let windows = await Task.detached { WindowInfo.createWindows(option: .onScreen) }.value
…
setFrame(newFrame, display: false)     // newFrame from the owningScreen snapshot
orderFrontRegardless()
```

The retention check runs *before* the await, so it says nothing about the panel's state when the method resumes. If the display configuration changes during the suspension, `MenuBarAppearanceManager` drains `overlayPanels` via `popFirst()` and orders every panel out. The suspended `show()` then resumes, computes a frame from the pre-change `owningScreen` snapshot and calls `orderFrontRegardless()`. The panel is back on screen at a stale position, is no longer in the manager's set, and therefore never receives an `orderOut` again.

The window enumeration is exactly the call that fire.10.4.1 moved off-main because it can block on a busy window server, so the suspension is not hypothetical: the wider the window it takes, the wider the race.

**Upstream is not affected.** On `macos-26` and `main`, `show()` is synchronous, so nothing separates the retention check from `orderFrontRegardless()`.

## Fix

Re-check retention after the await, before the panel is positioned. Five lines, no new threading, no behaviour change on the healthy path.

## Also in here: a dead comparison

```swift
while let panel = overlayPanels.popFirst() { panel.orderOut(self) }
if Set(overlayPanels.map { $0.owningScreen }) != Set(NSScreen.screens) { … }
```

`popFirst()` empties the set, so the comparison always evaluated an empty set against the current screens and was always true. Reconfiguring unconditionally is what effectively happened all along, so this is a readability change, not a behavioural one. Note that "repairing" the condition instead would be a regression: on a pure rearrangement the screen set is unchanged, the panels would stay ordered out and never come back.

This one is upstream's, present in both `main` and `macos-26`.

## Testing

`xcodebuild -project Ice.xcodeproj -scheme Ice -configuration Debug -destination 'platform=macOS'` per `AGENTS.md`: `** BUILD SUCCEEDED **`, no warnings from the touched files, SwiftLint phase clean.

The race itself is timing-dependent and I have no deterministic reproduction; the argument rests on the control flow and on the captured window list above. Happy to adjust if you would rather resolve `owningScreen` by display ID at the same time. I left that out on purpose to keep the change minimal, but it is the other half of the story: `NSScreen` instances are snapshots and are not updated in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNKCRYfFzqr1rk5td94i4C
